### PR TITLE
CI: build debug APK

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: "11"
+          distribution: "temurin"
+          cache: gradle
+      - name: Build with Gradle
+        run: ./gradlew assembleDebug
+      - uses: actions/upload-artifact@v2
+        with:
+          name: app-debug.apk
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
This PR adds a GitHub Action workflow to build and upload debug APK on each commit & PR against master branch.
However, GitHub Action won't work unless you merge them first so, you can check [Actions](https://github.com/Surendrajat/ViMusic/actions) run on my fork to see this in action :)

Closes #71 