### PR TITLE
Always use LTR layout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,6 @@
         android:icon="@mipmap/ic_launcher_round"
         android:label="${appName}"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
         android:theme="@style/Theme.ViMusic.NoActionBar">
 
         <activity

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/components/themed/DropdownMenu.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/components/themed/DropdownMenu.kt
@@ -133,7 +133,7 @@ private data class DropdownMenuPositionProvider(
         val toLeft = anchorBounds.right - contentOffsetX - popupContentSize.width
         val toDisplayRight = windowSize.width - popupContentSize.width
         val toDisplayLeft = 0
-        val x = if (layoutDirection == LayoutDirection.Ltr) {
+        val x =
             sequenceOf(
                 toRight,
                 toLeft,
@@ -141,15 +141,7 @@ private data class DropdownMenuPositionProvider(
                 // toDisplayLeft for proximity to the anchor. Otherwise, toDisplayRight.
                 if (anchorBounds.left >= 0) toDisplayRight else toDisplayLeft
             )
-        } else {
-            sequenceOf(
-                toLeft,
-                toRight,
-                // If the anchor gets outside of the window on the right, we want to position
-                // toDisplayRight for proximity to the anchor. Otherwise, toDisplayLeft.
-                if (anchorBounds.right <= windowSize.width) toDisplayLeft else toDisplayRight
-            )
-        }.firstOrNull {
+        .firstOrNull {
             it >= 0 && it + popupContentSize.width <= windowSize.width
         } ?: toLeft
 


### PR DESCRIPTION
ViMusic does not support any languages other than English (at least for the near future, see https://github.com/vfsfitvnm/ViMusic/pull/171#issuecomment-1206528846), and if the system language uses an RTL script (e.g. Arabic or Hebrew), the UI is broken in many places. For instance:

<img alt="RTL bug demonstration" src=https://user-images.githubusercontent.com/32234660/188449541-b5ce79ad-e2a4-4185-8a5d-1f7db237b0da.png height=400>

Tested and confirmed to be working.