### PR TITLE
Add an option to disable the search history

### DIFF
--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/Database.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/Database.kt
@@ -214,6 +214,9 @@ interface Database {
     @Query("SELECT loudnessDb FROM Format WHERE songId = :songId")
     fun loudnessDb(songId: String): Flow<Float?>
 
+    @Query("DELETE FROM SearchQuery")
+    fun clearSearchQueries()
+    
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(format: Format)
 

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/HomeScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -81,6 +82,7 @@ import it.vfsfitvnm.vimusic.utils.isFirstLaunchKey
 import it.vfsfitvnm.vimusic.utils.playlistGridExpandedKey
 import it.vfsfitvnm.vimusic.utils.playlistSortByKey
 import it.vfsfitvnm.vimusic.utils.playlistSortOrderKey
+import it.vfsfitvnm.vimusic.utils.preferences
 import it.vfsfitvnm.vimusic.utils.rememberPreference
 import it.vfsfitvnm.vimusic.utils.searchHistoryEnabledKey
 import it.vfsfitvnm.vimusic.utils.semiBold
@@ -92,12 +94,12 @@ import kotlinx.coroutines.Dispatchers
 @ExperimentalAnimationApi
 @Composable
 fun HomeScreen() {
+    val context = LocalContext.current
+
     val (colorPalette, typography) = LocalAppearance.current
 
     val lazyListState = rememberLazyListState()
     val lazyHorizontalGridState = rememberLazyGridState()
-
-    var searchHistoryEnabled by rememberPreference(searchHistoryEnabledKey, true)
 
     var playlistSortBy by rememberPreference(playlistSortByKey, PlaylistSortBy.DateAdded)
     var playlistSortOrder by rememberPreference(playlistSortOrderKey, SortOrder.Descending)
@@ -147,7 +149,11 @@ fun HomeScreen() {
                     searchResultRoute(query)
 
                     query {
-                        if (searchHistoryEnabled) Database.insert(SearchQuery(query = query))
+                        if (context.preferences.getBoolean(
+                                searchHistoryEnabledKey,
+                                true
+                            )
+                        ) Database.insert(SearchQuery(query = query))
                     }
                 },
                 onUri = { uri ->

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/HomeScreen.kt
@@ -82,6 +82,7 @@ import it.vfsfitvnm.vimusic.utils.playlistGridExpandedKey
 import it.vfsfitvnm.vimusic.utils.playlistSortByKey
 import it.vfsfitvnm.vimusic.utils.playlistSortOrderKey
 import it.vfsfitvnm.vimusic.utils.rememberPreference
+import it.vfsfitvnm.vimusic.utils.searchHistoryEnabledKey
 import it.vfsfitvnm.vimusic.utils.semiBold
 import it.vfsfitvnm.vimusic.utils.songSortByKey
 import it.vfsfitvnm.vimusic.utils.songSortOrderKey
@@ -95,6 +96,8 @@ fun HomeScreen() {
 
     val lazyListState = rememberLazyListState()
     val lazyHorizontalGridState = rememberLazyGridState()
+
+    var searchHistoryEnabled by rememberPreference(searchHistoryEnabledKey, true)
 
     var playlistSortBy by rememberPreference(playlistSortByKey, PlaylistSortBy.DateAdded)
     var playlistSortOrder by rememberPreference(playlistSortOrderKey, SortOrder.Descending)
@@ -144,7 +147,7 @@ fun HomeScreen() {
                     searchResultRoute(query)
 
                     query {
-                        Database.insert(SearchQuery(query = query))
+                        if (searchHistoryEnabled) Database.insert(SearchQuery(query = query))
                     }
                 },
                 onUri = { uri ->

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/SearchScreen.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/SearchScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -63,12 +64,15 @@ import it.vfsfitvnm.vimusic.Database
 import it.vfsfitvnm.vimusic.R
 import it.vfsfitvnm.vimusic.models.SearchQuery
 import it.vfsfitvnm.vimusic.query
+import it.vfsfitvnm.vimusic.ui.components.ChunkyButton
 import it.vfsfitvnm.vimusic.ui.components.TopAppBar
 import it.vfsfitvnm.vimusic.ui.styling.Dimensions
 import it.vfsfitvnm.vimusic.ui.components.themed.LoadingOrError
 import it.vfsfitvnm.vimusic.ui.styling.LocalAppearance
+import it.vfsfitvnm.vimusic.utils.color
 import it.vfsfitvnm.vimusic.utils.medium
 import it.vfsfitvnm.vimusic.utils.secondary
+import it.vfsfitvnm.vimusic.utils.semiBold
 import it.vfsfitvnm.youtubemusic.YouTube
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -272,6 +276,8 @@ fun SearchScreen(initialTextInput: String, onSearch: (String) -> Unit, onUri: (U
                 }
 
                 LazyColumn(
+                    modifier = Modifier
+                        .weight(1.0f),
                     contentPadding = PaddingValues(
                         bottom = Dimensions.collapsedPlayer + paddingValues.calculateBottomPadding()
                     )
@@ -394,6 +400,22 @@ fun SearchScreen(initialTextInput: String, onSearch: (String) -> Unit, onUri: (U
                         }
                     }
                 }
+
+                if (history.isNotEmpty()) ChunkyButton(
+                    modifier = Modifier.align(
+                        alignment = Alignment.End
+                    )
+                        .padding(10.dp),
+                    backgroundColor = colorPalette.accent,
+                    text = "Clear history",
+                    textStyle = typography.xs.semiBold.color(colorPalette.onAccent),
+                    shape = RoundedCornerShape(36.dp),
+                    onClick = {
+                        query {
+                            Database.clearSearchQueries()
+                        }
+                    }
+                )
             }
         }
     }

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/settings/OtherSettingsScreen.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/settings/OtherSettingsScreen.kt
@@ -31,8 +31,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import it.vfsfitvnm.route.RouteHandler
+import it.vfsfitvnm.vimusic.Database
 import it.vfsfitvnm.vimusic.LocalPlayerAwarePaddingValues
 import it.vfsfitvnm.vimusic.R
+import it.vfsfitvnm.vimusic.query
 import it.vfsfitvnm.vimusic.ui.components.TopAppBar
 import it.vfsfitvnm.vimusic.ui.screens.SettingsDescription
 import it.vfsfitvnm.vimusic.ui.screens.SettingsEntry
@@ -44,12 +46,12 @@ import it.vfsfitvnm.vimusic.ui.styling.LocalAppearance
 import it.vfsfitvnm.vimusic.utils.isIgnoringBatteryOptimizations
 import it.vfsfitvnm.vimusic.utils.isInvincibilityEnabledKey
 import it.vfsfitvnm.vimusic.utils.rememberPreference
+import it.vfsfitvnm.vimusic.utils.searchHistoryEnabledKey
 import it.vfsfitvnm.vimusic.utils.semiBold
 
 @ExperimentalAnimationApi
 @Composable
 fun OtherSettingsScreen() {
-
     val scrollState = rememberScrollState()
 
     RouteHandler(listenToGlobalEmitter = true) {
@@ -64,6 +66,8 @@ fun OtherSettingsScreen() {
             var isIgnoringBatteryOptimizations by remember {
                 mutableStateOf(context.isIgnoringBatteryOptimizations)
             }
+
+            var searchHistoryEnabled by rememberPreference(searchHistoryEnabledKey, true)
 
             val activityResultLauncher =
                 rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
@@ -150,6 +154,18 @@ fun OtherSettingsScreen() {
                     isChecked = isInvincibilityEnabled,
                     onCheckedChange = {
                         isInvincibilityEnabled = it
+                    }
+                )
+
+                SwitchSettingEntry(
+                    title = "Search history",
+                    text = "Store the latest search queries",
+                    isChecked = searchHistoryEnabled,
+                    onCheckedChange = {
+                        query {
+                            if (!it) Database.clearSearchQueries()
+                        }
+                        searchHistoryEnabled = it
                     }
                 )
             }

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/settings/OtherSettingsScreen.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/settings/OtherSettingsScreen.kt
@@ -162,9 +162,6 @@ fun OtherSettingsScreen() {
                     text = "Store the latest search queries",
                     isChecked = searchHistoryEnabled,
                     onCheckedChange = {
-                        query {
-                            if (!it) Database.clearSearchQueries()
-                        }
                         searchHistoryEnabled = it
                     }
                 )

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/utils/Preferences.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/utils/Preferences.kt
@@ -29,6 +29,7 @@ const val volumeNormalizationKey = "volumeNormalization"
 const val persistentQueueKey = "persistentQueue"
 const val isShowingSynchronizedLyricsKey = "isShowingSynchronizedLyrics"
 const val isShowingThumbnailInLockscreenKey = "isShowingThumbnailInLockscreen"
+const val searchHistoryEnabledKey = "searchHistoryEnabled"
 
 inline fun <reified T : Enum<T>> SharedPreferences.getEnum(
     key: String,


### PR DESCRIPTION
Hey,

first of all congrats for developing such a great app, I've been using it for a few weeks now and must admit that using it is really a neat experience :)

I personally am not a big fan of various histories, e.g. search histories, that's why I often come back to clearing it manually after a certain time.
This PR adds a simple switch to the preferences which will allow toggling whether the search history is enabled. When disabling the search history, it'll be cleared (not sure if that's the best way to handle it but didn't want to add a separate button for it).

I saw that you stated out that you're the only one having contributed to the codebase so far, I wouldn't complain if you'd commit it yourself if you prefer to do so ;)

Cheers