### PR TITLE
Remove songs from the queue by swiping

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         minSdk = 21
         targetSdk = 33
         versionCode = 20
-        versionName = "0.5.4"
+        versionName = "1.0.1"
     }
 
     splits {

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/album/AlbumScreen.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/album/AlbumScreen.kt
@@ -67,7 +67,7 @@ fun AlbumScreen(browseId: String) {
             .collect { (currentAlbum, tabIndex) ->
                 album = currentAlbum
 
-                if (albumPage == null && (currentAlbum?.timestamp == null || tabIndex == 1)) {
+                if (albumPage == null && (currentAlbum?.timestamp == null || currentAlbum.title == null || tabIndex == 1)) {
                     withContext(Dispatchers.IO) {
                         Innertube.albumPage(BrowseBody(browseId = browseId))
                             ?.onSuccess { currentAlbumPage ->

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Queue.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Queue.kt
@@ -42,6 +42,7 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -191,6 +192,10 @@ fun Queue(
 
         val musicBarsTransition = updateTransition(targetState = mediaItemIndex, label = "")
 
+        val deleteHistory = remember {
+            mutableStateListOf<String>()
+        }
+
         Column {
             Box(
                 modifier = Modifier
@@ -303,12 +308,27 @@ fun Queue(
                                     }),
                                     onDragStopped = { _ ->
                                         if (offsetX.value.x >= 200.0f || offsetX.value.x <= -200.0f) {
+                                            val currentIndex = window.firstPeriodIndex
+                                            val mediaId = window.mediaItem.mediaId
+
+                                            if (deleteHistory.indexOf(mediaId) != -1) return@draggable
+                                            deleteHistory.add(mediaId)
+
+                                            var indexToDelete = currentIndex
+                                            for (i in 0 until currentIndex) {
+                                                if (deleteHistory.indexOf(windows.elementAt(i).mediaItem.mediaId) != -1) {
+                                                    indexToDelete--
+                                                }
+                                            }
+
                                             if (offsetX.value.x < 0) {
                                                 offsetX.animateTo(Offset(-1500.0f, offsetX.value.y))
                                             } else {
                                                 offsetX.animateTo(Offset(1500.0f, offsetX.value.y))
                                             }
-                                            binder.player.removeMediaItem(window.firstPeriodIndex)
+
+                                            binder.player.removeMediaItem(indexToDelete)
+                                            deleteHistory.removeFirst()
                                         } else {
                                             offsetX.animateTo(Offset(0f, offsetX.value.y))
                                         }

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Queue.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Queue.kt
@@ -296,8 +296,8 @@ fun Queue(
                                         if (isPlayingThisMediaItem) return@rememberDraggableState
                                         offsetX += delta
                                     }),
-                                    onDragStopped = { velocity ->
-                                        if ((offsetX <= -300.0f && velocity <= -3000.0f) || (offsetX >= 300.0f && velocity >= 3000.0f)) {
+                                    onDragStopped = { _ ->
+                                        if (offsetX >= 200.0f || offsetX <= -200.0f) {
                                             binder.player.removeMediaItem(window.firstPeriodIndex)
                                         } else {
                                             offsetX = 0f

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Queue.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Queue.kt
@@ -15,6 +15,9 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -25,6 +28,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -48,6 +52,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
@@ -82,6 +87,7 @@ import it.vfsfitvnm.vimusic.utils.shuffleQueue
 import it.vfsfitvnm.vimusic.utils.smoothScrollToTop
 import it.vfsfitvnm.vimusic.utils.windows
 import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 @ExperimentalFoundationApi
 @ExperimentalAnimationApi
@@ -202,6 +208,7 @@ fun Queue(
                         key = { it.uid.hashCode() }
                     ) { window ->
                         val isPlayingThisMediaItem = mediaItemIndex == window.firstPeriodIndex
+                        var offsetX by remember { mutableStateOf(0f) }
 
                         SongItem(
                             song = window.mediaItem,
@@ -283,6 +290,21 @@ fun Queue(
                                     reorderingState = reorderingState,
                                     index = window.firstPeriodIndex
                                 )
+                                .draggable(
+                                    orientation = Orientation.Horizontal,
+                                    state = rememberDraggableState(onDelta = { delta ->
+                                        if (isPlayingThisMediaItem) return@rememberDraggableState
+                                        offsetX += delta
+                                    }),
+                                    onDragStopped = { velocity ->
+                                        if ((offsetX <= -300.0f && velocity <= -3000.0f) || (offsetX >= 300.0f && velocity >= 3000.0f)) {
+                                            binder.player.removeMediaItem(window.firstPeriodIndex)
+                                        } else {
+                                            offsetX = 0f
+                                        }
+                                    }
+                                )
+                                .offset{ IntOffset(offsetX.roundToInt(), 0) }
                         )
                     }
 

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/BrowseResponse.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/BrowseResponse.kt
@@ -13,6 +13,7 @@ data class BrowseResponse(
     @Serializable
     data class Contents(
         val singleColumnBrowseResultsRenderer: Tabs?,
+        val twoColumnBrowseResultsRenderer: TwoColResults?,
         val sectionListRenderer: SectionListRenderer?,
     )
 

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/MusicShelfRenderer.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/MusicShelfRenderer.kt
@@ -7,7 +7,9 @@ data class MusicShelfRenderer(
     val bottomEndpoint: NavigationEndpoint?,
     val contents: List<Content>?,
     val continuations: List<Continuation>?,
-    val title: Runs?
+    val title: Runs?,
+    val thumbnail: ThumbnailRenderer?,
+    val subtitle: Runs?
 ) {
     @Serializable
     data class Content(
@@ -23,7 +25,7 @@ data class MusicShelfRenderer(
                 ?: emptyList()) to
                     (musicResponsiveListItemRenderer
                         ?.flexColumns
-                        ?.lastOrNull()
+                        ?.getOrNull(1)
                         ?.musicResponsiveListItemFlexColumnRenderer
                         ?.text
                         ?.splitBySeparator()

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/SectionListRenderer.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/SectionListRenderer.kt
@@ -16,6 +16,8 @@ data class SectionListRenderer(
         val musicCarouselShelfRenderer: MusicCarouselShelfRenderer?,
         @JsonNames("musicPlaylistShelfRenderer")
         val musicShelfRenderer: MusicShelfRenderer?,
+        val musicResponsiveHeaderRenderer: MusicShelfRenderer?,
+        val musicPlaylistShelfRenderer: MusicShelfRenderer?,
         val gridRenderer: GridRenderer?,
         val musicDescriptionShelfRenderer: MusicDescriptionShelfRenderer?,
     ) {

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/TwoColResults.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/TwoColResults.kt
@@ -1,0 +1,14 @@
+package it.vfsfitvnm.innertube.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TwoColResults(
+    val secondaryContents: SecondaryContents?,
+    val tabs: List<Tabs.Tab>?
+) {
+    @Serializable
+    data class SecondaryContents(
+        val sectionListRenderer: SectionListRenderer?
+    )
+}

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/requests/ItemsPage.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/requests/ItemsPage.kt
@@ -37,7 +37,7 @@ suspend fun <T : Innertube.Item> Innertube.itemsPage(
 
     itemsPageFromMusicShelRendererOrGridRenderer(
         musicShelfRenderer = sectionListRendererContent
-            ?.musicShelfRenderer,
+            ?.musicPlaylistShelfRenderer,
         gridRenderer = sectionListRendererContent
             ?.gridRenderer,
         fromMusicResponsiveListItemRenderer = fromMusicResponsiveListItemRenderer,

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/requests/PlaylistPage.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/requests/PlaylistPage.kt
@@ -16,26 +16,31 @@ import it.vfsfitvnm.innertube.utils.runCatchingNonCancellable
 suspend fun Innertube.playlistPage(body: BrowseBody) = runCatchingNonCancellable {
     val response = client.post(browse) {
         setBody(body)
-        mask("contents.singleColumnBrowseResultsRenderer.tabs.tabRenderer.content.sectionListRenderer.contents(musicPlaylistShelfRenderer(continuations,contents.$musicResponsiveListItemRendererMask),musicCarouselShelfRenderer.contents.$musicTwoRowItemRendererMask),header.musicDetailHeaderRenderer(title,subtitle,thumbnail),microformat")
+        mask("contents.twoColumnBrowseResultsRenderer(tabs.tabRenderer.content.sectionListRenderer.contents.musicResponsiveHeaderRenderer(title,subtitle,thumbnail),secondaryContents.sectionListRenderer.contents(musicPlaylistShelfRenderer(continuations,contents.$musicResponsiveListItemRendererMask),musicCarouselShelfRenderer.contents.$musicTwoRowItemRendererMask)),microformat")
     }.body<BrowseResponse>()
 
     val musicDetailHeaderRenderer = response
-        .header
-        ?.musicDetailHeaderRenderer
-
-    val sectionListRendererContents = response
         .contents
-        ?.singleColumnBrowseResultsRenderer
+        ?.twoColumnBrowseResultsRenderer
         ?.tabs
         ?.firstOrNull()
         ?.tabRenderer
         ?.content
         ?.sectionListRenderer
         ?.contents
+        ?.firstOrNull()
+        ?.musicResponsiveHeaderRenderer
+
+    val sectionListRendererContents = response
+        .contents
+        ?.twoColumnBrowseResultsRenderer
+        ?.secondaryContents
+        ?.sectionListRenderer
+        ?.contents
 
     val musicShelfRenderer = sectionListRendererContents
         ?.firstOrNull()
-        ?.musicShelfRenderer
+        ?.musicPlaylistShelfRenderer
 
     val musicCarouselShelfRenderer = sectionListRendererContents
         ?.getOrNull(1)


### PR DESCRIPTION
I love using this app but find it slightly tedious to have to hold down on each song in the queue to remove it. Therefore, based on issue #540, I've decided to add this feature. Please let me know if this would be an appropriate enhancement to this wonderful app!