### PR TITLE
added link to artist page

### DIFF
--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Controls.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Controls.kt
@@ -38,10 +38,12 @@ import androidx.media3.common.Player
 import it.vfsfitvnm.vimusic.Database
 import it.vfsfitvnm.vimusic.LocalPlayerServiceBinder
 import it.vfsfitvnm.vimusic.R
+import it.vfsfitvnm.vimusic.models.Info
 import it.vfsfitvnm.vimusic.models.Song
 import it.vfsfitvnm.vimusic.query
 import it.vfsfitvnm.vimusic.ui.components.SeekBar
 import it.vfsfitvnm.vimusic.ui.components.themed.IconButton
+import it.vfsfitvnm.vimusic.ui.screens.artistRoute
 import it.vfsfitvnm.vimusic.ui.styling.LocalAppearance
 import it.vfsfitvnm.vimusic.ui.styling.favoritesIcon
 import it.vfsfitvnm.vimusic.utils.bold
@@ -52,7 +54,9 @@ import it.vfsfitvnm.vimusic.utils.rememberPreference
 import it.vfsfitvnm.vimusic.utils.secondary
 import it.vfsfitvnm.vimusic.utils.semiBold
 import it.vfsfitvnm.vimusic.utils.trackLoopEnabledKey
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.withContext
 
 @Composable
 fun Controls(
@@ -79,8 +83,14 @@ fun Controls(
         mutableStateOf<Long?>(null)
     }
 
-    LaunchedEffect(mediaId) {
-        Database.likedAt(mediaId).distinctUntilChanged().collect { likedAt = it }
+    var artistsInfo: List<Info>? by remember { mutableStateOf(null) }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            if (artistsInfo == null) artistsInfo = Database.songArtistInfo(mediaId)
+
+            Database.likedAt(mediaId).distinctUntilChanged().collect { likedAt = it }
+        }
     }
 
     val shouldBePlayingTransition = updateTransition(shouldBePlaying, label = "shouldBePlaying")
@@ -113,7 +123,11 @@ fun Controls(
             text = artist ?: "",
             style = typography.s.semiBold.secondary,
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.clickable {
+                val goTo = artistRoute::global
+                goTo(artistsInfo?.get(0)?.id)
+            }
         )
 
         Spacer(


### PR DESCRIPTION
Clicking on the artist name in the song player below the title of the song will navigate to the artist page. I believe this is consistent with most music player apps.

Ex) Spotify and the youtube music app have a feature where clicking on the artist name below the title of the page changes the page to the artist page. 

The current way to access the artist page from ViMusic is to press the ellipses on the bottom right corner then "More of {artist}" button which requires an additional step. Instead of two steps, it should only take one. Adding the link to the artist name is a more intuitive approach and requires less friction, improving user experience because visiting the artist page is a common action.

![demo](https://github.com/vfsfitvnm/ViMusic/assets/81270095/9d38011c-accd-4a0f-b6e4-688fcb0a0d77)
