### PR TITLE
Upgrade to gradle 8.2.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,18 +1,7 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build", "gradle", "7.3.0")
-        classpath(kotlin("gradle-plugin", libs.versions.kotlin.get()))
-    }
-}
-
-tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
+@Suppress("DSL_SCOPE_VIOLATION")
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
 }
 
 subprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,6 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.enableR8.fullMode=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp="7.3.0"
+agp= "8.2.1"
 brotli="0.1.2"
 kotlin = "1.7.20"
 compose-compiler = "1.3.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+agp="7.3.0"
 brotli="0.1.2"
 kotlin = "1.7.20"
 compose-compiler = "1.3.2"
@@ -39,3 +40,5 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 [plugins]
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-android = {id = "org.jetbrains.kotlin.android", version.ref = "kotlin"}
+android-application = {id = "com.android.application", version.ref = "agp"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,41 @@
+[versions]
+brotli="0.1.2"
+kotlin = "1.7.20"
+compose-compiler = "1.3.2"
+compose = "1.3.0-rc01"
+compose-activity="1.7.0-alpha01"
+compose-coil="2.2.2"
+coroutines= "1.6.4"
+compose-shimmer="1.0.3"
+room = "2.5.0-beta01"
+media3 = "1.0.0-beta03"
+palette="1.0.0"
+ktor = "2.1.2"
+desugaring = "1.1.5"
+junit = "4.13.2"
+
+[libraries]
+kotlin-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "compose" }
+compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
+compose-ui-util = { group = "androidx.compose.ui", name = "ui-util", version.ref = "compose" }
+compose-ripple = { group = "androidx.compose.material", name = "material-ripple", version.ref = "compose" }
+compose-shimmer = { group = "com.valentinilk.shimmer", name = "compose-shimmer", version.ref = "compose-shimmer" }
+compose-activity = { group = "androidx.activity", name = "activity-compose", version.ref = "compose-activity" }
+compose-coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "compose-coil" }
+room = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-encoding = { group = "io.ktor", name = "ktor-client-encoding", version.ref = "ktor" }
+ktor-client-serialization = { group = "io.ktor", name = "ktor-client-serialization", version.ref = "ktor" }
+ktor-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+brotli = { group = "org.brotli", name = "dec", version.ref = "brotli" }
+palette = { group = "androidx.palette", name = "palette", version.ref = "palette" }
+desugaring = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugaring" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+
+[plugins]
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 06 23:33:16 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/innertube/build.gradle.kts
+++ b/innertube/build.gradle.kts
@@ -19,5 +19,5 @@ dependencies {
     implementation(libs.ktor.client.serialization)
     implementation(libs.ktor.serialization.json)
 
-    testImplementation(testLibs.junit)
+    testImplementation(libs.junit)
 }

--- a/kugou/build.gradle.kts
+++ b/kugou/build.gradle.kts
@@ -18,5 +18,5 @@ dependencies {
     implementation(libs.ktor.client.serialization)
     implementation(libs.ktor.serialization.json)
 
-    testImplementation(testLibs.junit)
+    testImplementation(libs.junit)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,13 @@
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,54 +8,6 @@ dependencyResolutionManagement {
         mavenCentral()
         maven { setUrl("https://jitpack.io") }
     }
-
-    versionCatalogs {
-        create("libs") {
-            version("kotlin", "1.7.20")
-            plugin("kotlin-serialization","org.jetbrains.kotlin.plugin.serialization").versionRef("kotlin")
-
-            library("kotlin-coroutines","org.jetbrains.kotlinx", "kotlinx-coroutines-core").version("1.6.4")
-
-            version("compose-compiler", "1.3.2")
-
-            version("compose", "1.3.0-rc01")
-            library("compose-foundation", "androidx.compose.foundation", "foundation").versionRef("compose")
-            library("compose-ui", "androidx.compose.ui", "ui").versionRef("compose")
-            library("compose-ui-util", "androidx.compose.ui", "ui-util").versionRef("compose")
-            library("compose-ripple", "androidx.compose.material", "material-ripple").versionRef("compose")
-
-            library("compose-shimmer", "com.valentinilk.shimmer", "compose-shimmer").version("1.0.3")
-
-            library("compose-activity", "androidx.activity", "activity-compose").version("1.7.0-alpha01")
-
-            library("compose-coil", "io.coil-kt", "coil-compose").version("2.2.2")
-
-            version("room", "2.5.0-beta01")
-            library("room", "androidx.room", "room-ktx").versionRef("room")
-            library("room-compiler", "androidx.room", "room-compiler").versionRef("room")
-
-            version("media3", "1.0.0-beta03")
-            library("exoplayer", "androidx.media3", "media3-exoplayer").versionRef("media3")
-
-            version("ktor", "2.1.2")
-            library("ktor-client-core", "io.ktor", "ktor-client-core").versionRef("ktor")
-            library("ktor-client-cio", "io.ktor", "ktor-client-okhttp").versionRef("ktor")
-            library("ktor-client-content-negotiation", "io.ktor", "ktor-client-content-negotiation").versionRef("ktor")
-            library("ktor-client-encoding", "io.ktor", "ktor-client-encoding").versionRef("ktor")
-            library("ktor-client-serialization", "io.ktor", "ktor-client-serialization").versionRef("ktor")
-            library("ktor-serialization-json", "io.ktor", "ktor-serialization-kotlinx-json").versionRef("ktor")
-
-            library("brotli", "org.brotli", "dec").version("0.1.2")
-
-            library("palette", "androidx.palette", "palette").version("1.0.0")
-
-            library("desugaring", "com.android.tools", "desugar_jdk_libs").version("1.1.5")
-        }
-
-        create("testLibs") {
-            library("junit", "junit", "junit").version("4.13.2")
-        }
-    }
 }
 
 rootProject.name = "ViMusic"


### PR DESCRIPTION
# Issues
Fixes: #1411 

# Description
To upgrade gradle, I've used the `APG Upgrade Assistant` in Android Studio.

Upgrade assistant cannot work with the `version-catalogue` in settings.gradle file, so first I migrated to use `libs.versions.toml`. In general, Android Studio gives better support for dependencies when using toml file.

Also, with latest gradle version, instead of `classpath`, `plugins` are used. So migrated to plugins.

Task `clean` is already created by latest android studio, so removed it.

# How this has been tested
Project builds successfully and installs

# Tested On
Emulator: Pixel 3a API 33
Physical: Poco X3 NFC, LineageOS, API 33

# Additional Info

<img width="913" alt="Screenshot 2024-01-05 at 8 31 58 PM" src="https://github.com/vfsfitvnm/ViMusic/assets/69595691/3fd64198-9380-446e-b30e-075bd16cd38a">

 
<img width="1217" alt="Screenshot 2024-01-05 at 8 32 15 PM" src="https://github.com/vfsfitvnm/ViMusic/assets/69595691/aad1d8d2-6243-4467-a361-ba9237f5d95b">
