### PR TITLE
fix(playlist): usage of new youtube api format for playlists/albums

### DIFF
--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/album/AlbumScreen.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/album/AlbumScreen.kt
@@ -67,7 +67,7 @@ fun AlbumScreen(browseId: String) {
             .collect { (currentAlbum, tabIndex) ->
                 album = currentAlbum
 
-                if (albumPage == null && (currentAlbum?.timestamp == null || tabIndex == 1)) {
+                if (albumPage == null && (currentAlbum?.timestamp == null || currentAlbum.title == null || tabIndex == 1)) {
                     withContext(Dispatchers.IO) {
                         Innertube.albumPage(BrowseBody(browseId = browseId))
                             ?.onSuccess { currentAlbumPage ->

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/BrowseResponse.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/BrowseResponse.kt
@@ -13,6 +13,7 @@ data class BrowseResponse(
     @Serializable
     data class Contents(
         val singleColumnBrowseResultsRenderer: Tabs?,
+        val twoColumnBrowseResultsRenderer: TwoColResults?,
         val sectionListRenderer: SectionListRenderer?,
     )
 

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/MusicShelfRenderer.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/MusicShelfRenderer.kt
@@ -7,7 +7,9 @@ data class MusicShelfRenderer(
     val bottomEndpoint: NavigationEndpoint?,
     val contents: List<Content>?,
     val continuations: List<Continuation>?,
-    val title: Runs?
+    val title: Runs?,
+    val thumbnail: ThumbnailRenderer?,
+    val subtitle: Runs?
 ) {
     @Serializable
     data class Content(

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/MusicShelfRenderer.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/MusicShelfRenderer.kt
@@ -25,7 +25,7 @@ data class MusicShelfRenderer(
                 ?: emptyList()) to
                     (musicResponsiveListItemRenderer
                         ?.flexColumns
-                        ?.lastOrNull()
+                        ?.getOrNull(1)
                         ?.musicResponsiveListItemFlexColumnRenderer
                         ?.text
                         ?.splitBySeparator()

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/SectionListRenderer.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/SectionListRenderer.kt
@@ -16,6 +16,8 @@ data class SectionListRenderer(
         val musicCarouselShelfRenderer: MusicCarouselShelfRenderer?,
         @JsonNames("musicPlaylistShelfRenderer")
         val musicShelfRenderer: MusicShelfRenderer?,
+        val musicResponsiveHeaderRenderer: MusicShelfRenderer?,
+        val musicPlaylistShelfRenderer: MusicShelfRenderer?,
         val gridRenderer: GridRenderer?,
         val musicDescriptionShelfRenderer: MusicDescriptionShelfRenderer?,
     ) {

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/TwoColResults.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/models/TwoColResults.kt
@@ -1,0 +1,14 @@
+package it.vfsfitvnm.innertube.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TwoColResults (
+    val secondaryContents: SecondaryContents?,
+    val tabs: List<Tabs.Tab>?
+) {
+    @Serializable
+    data class SecondaryContents (
+        val sectionListRenderer: SectionListRenderer?
+    )
+}

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/requests/ItemsPage.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/requests/ItemsPage.kt
@@ -37,7 +37,7 @@ suspend fun <T : Innertube.Item> Innertube.itemsPage(
 
     itemsPageFromMusicShelRendererOrGridRenderer(
         musicShelfRenderer = sectionListRendererContent
-            ?.musicShelfRenderer,
+            ?.musicPlaylistShelfRenderer,
         gridRenderer = sectionListRendererContent
             ?.gridRenderer,
         fromMusicResponsiveListItemRenderer = fromMusicResponsiveListItemRenderer,

--- a/innertube/src/main/kotlin/it/vfsfitvnm/innertube/requests/PlaylistPage.kt
+++ b/innertube/src/main/kotlin/it/vfsfitvnm/innertube/requests/PlaylistPage.kt
@@ -5,8 +5,10 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import it.vfsfitvnm.innertube.Innertube
 import it.vfsfitvnm.innertube.models.BrowseResponse
+import it.vfsfitvnm.innertube.models.Continuation
 import it.vfsfitvnm.innertube.models.ContinuationResponse
 import it.vfsfitvnm.innertube.models.MusicCarouselShelfRenderer
+import it.vfsfitvnm.innertube.models.MusicResponsiveListItemRenderer
 import it.vfsfitvnm.innertube.models.MusicShelfRenderer
 import it.vfsfitvnm.innertube.models.bodies.BrowseBody
 import it.vfsfitvnm.innertube.models.bodies.ContinuationBody
@@ -16,26 +18,31 @@ import it.vfsfitvnm.innertube.utils.runCatchingNonCancellable
 suspend fun Innertube.playlistPage(body: BrowseBody) = runCatchingNonCancellable {
     val response = client.post(browse) {
         setBody(body)
-        mask("contents.singleColumnBrowseResultsRenderer.tabs.tabRenderer.content.sectionListRenderer.contents(musicPlaylistShelfRenderer(continuations,contents.$musicResponsiveListItemRendererMask),musicCarouselShelfRenderer.contents.$musicTwoRowItemRendererMask),header.musicDetailHeaderRenderer(title,subtitle,thumbnail),microformat")
+        mask("contents.twoColumnBrowseResultsRenderer(tabs.tabRenderer.content.sectionListRenderer.contents.musicResponsiveHeaderRenderer(title,subtitle,thumbnail),secondaryContents.sectionListRenderer.contents(musicPlaylistShelfRenderer(continuations,contents.$musicResponsiveListItemRendererMask),musicCarouselShelfRenderer.contents.$musicTwoRowItemRendererMask)),microformat")
     }.body<BrowseResponse>()
 
     val musicDetailHeaderRenderer = response
-        .header
-        ?.musicDetailHeaderRenderer
-
-    val sectionListRendererContents = response
         .contents
-        ?.singleColumnBrowseResultsRenderer
+        ?.twoColumnBrowseResultsRenderer
         ?.tabs
         ?.firstOrNull()
         ?.tabRenderer
         ?.content
         ?.sectionListRenderer
         ?.contents
+        ?.firstOrNull()
+        ?.musicResponsiveHeaderRenderer
+
+    val sectionListRendererContents = response
+        .contents
+        ?.twoColumnBrowseResultsRenderer
+        ?.secondaryContents
+        ?.sectionListRenderer
+        ?.contents
 
     val musicShelfRenderer = sectionListRendererContents
         ?.firstOrNull()
-        ?.musicShelfRenderer
+        ?.musicPlaylistShelfRenderer
 
     val musicCarouselShelfRenderer = sectionListRendererContents
         ?.getOrNull(1)


### PR DESCRIPTION
About a week ago, youtube apparently changed it's api, breaking a lot of apps like this one (see #1632, #1652, #1650, #1649, #1648, #1647, #1646, #1645, #1644, #1643, #1640, #1638, #1636, #1634, #1639); this is a rather quick-and-dirty fix to extract playlist/album info after this api change.

For everyone that cannot wait until this gets merged (if it does) and can't build the app themselves: 

# DOWNLOAD HERE ↓↓↓
[app-release.zip](https://github.com/user-attachments/files/16118733/app-release.zip)

# DISCLAIMER

You will not be able to install this over an existing install from eg. f-droid because this apk is not signed and I don't have the keys to do so. You should be able to uninstall and then install this version, but note that **ALL YOUR DATA WILL BE GONE**, so back up before.

# DOWNLOAD HERE ↑↑↑ 

### Update 2024-06-30:
The problem was there also for the song list of an artist - this is fixed now too.

### Update 2024-07-04:
As @ andietablante18 pointed out, artist names were not shown in song search results; this now works again as well.

### Update 2024-07-07:
Old databases may contain cached information scraped using the wrong api format and are thus still displayed as 'Unknown'; this patch now updates these albums as they are loaded. Thanks @ KingK2-gif for the reproducing example.
